### PR TITLE
Avoid load parent in block verification

### DIFF
--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -40,6 +40,7 @@ macro_rules! easy_from_to {
 pub enum BeaconChainError {
     InsufficientValidators,
     UnableToReadSlot,
+    UnableToComputeTimeAtSlot,
     RevertedFinalizedEpoch {
         previous_epoch: Epoch,
         new_epoch: Epoch,

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Checkpoint, Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(5);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(6);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //

--- a/common/slot_clock/src/manual_slot_clock.rs
+++ b/common/slot_clock/src/manual_slot_clock.rs
@@ -154,6 +154,10 @@ impl SlotClock for ManualSlotClock {
     fn genesis_slot(&self) -> Slot {
         self.genesis_slot
     }
+
+    fn genesis_duration(&self) -> Duration {
+        self.genesis_duration
+    }
 }
 
 #[cfg(test)]

--- a/common/slot_clock/src/system_time_slot_clock.rs
+++ b/common/slot_clock/src/system_time_slot_clock.rs
@@ -61,6 +61,10 @@ impl SlotClock for SystemTimeSlotClock {
     fn genesis_slot(&self) -> Slot {
         self.clock.genesis_slot()
     }
+
+    fn genesis_duration(&self) -> Duration {
+        *self.clock.genesis_duration()
+    }
 }
 
 #[cfg(test)]

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -23,6 +23,7 @@ pub enum Error<T> {
     InvalidBlock(InvalidBlock),
     ProtoArrayError(String),
     InvalidProtoArrayBytes(String),
+    InvalidLegacyProtoArrayBytes(String),
     MissingProtoArrayBlock(Hash256),
     UnknownAncestor {
         ancestor_slot: Slot,
@@ -279,6 +280,12 @@ where
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
+        // Default any non-merge execution block hashes to 0x000..000.
+        let execution_block_hash = anchor_block.message_merge().map_or_else(
+            |()| Hash256::zero(),
+            |message| message.body.execution_payload.block_hash,
+        );
+
         let proto_array = ProtoArrayForkChoice::new(
             finalized_block_slot,
             finalized_block_state_root,
@@ -287,6 +294,7 @@ where
             fc_store.finalized_checkpoint().root,
             current_epoch_shuffling_id,
             next_epoch_shuffling_id,
+            execution_block_hash,
         )?;
 
         Ok(Self {
@@ -576,6 +584,12 @@ where
             .on_verified_block(block, block_root, state)
             .map_err(Error::AfterBlockFailed)?;
 
+        // Default any non-merge execution block hashes to 0x000..000.
+        let execution_block_hash = block.body_merge().map_or_else(
+            |()| Hash256::zero(),
+            |body| body.execution_payload.block_hash,
+        );
+
         // This does not apply a vote to the block, it just makes fork choice aware of the block so
         // it can still be identified as the head even if it doesn't have any votes.
         self.proto_array.process_block(ProtoBlock {
@@ -598,6 +612,7 @@ where
             state_root: block.state_root(),
             justified_epoch: state.current_justified_checkpoint().epoch,
             finalized_epoch: state.finalized_checkpoint().epoch,
+            execution_block_hash,
         })?;
 
         Ok(())
@@ -893,7 +908,7 @@ where
 /// This is used when persisting the state of the fork choice to disk.
 #[derive(Encode, Decode, Clone)]
 pub struct PersistedForkChoice {
-    proto_array_bytes: Vec<u8>,
+    pub proto_array_bytes: Vec<u8>,
     queued_attestations: Vec<QueuedAttestation>,
 }
 

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -57,6 +57,7 @@ impl ForkChoiceTestDefinition {
     pub fn run(self) {
         let junk_shuffling_id =
             AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
+        let execution_block_hash = Hash256::zero();
         let mut fork_choice = ProtoArrayForkChoice::new(
             self.finalized_block_slot,
             Hash256::zero(),
@@ -65,6 +66,7 @@ impl ForkChoiceTestDefinition {
             self.finalized_root,
             junk_shuffling_id.clone(),
             junk_shuffling_id,
+            execution_block_hash,
         )
         .expect("should create fork choice struct");
 
@@ -139,6 +141,7 @@ impl ForkChoiceTestDefinition {
                         ),
                         justified_epoch,
                         finalized_epoch,
+                        execution_block_hash,
                     };
                     fork_choice.process_block(block).unwrap_or_else(|e| {
                         panic!(

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -2,9 +2,10 @@ use super::per_block_processing::{
     errors::BlockProcessingError, process_operations::process_deposit,
 };
 use crate::common::DepositDataTree;
-use crate::upgrade::upgrade_to_altair;
+use crate::upgrade::{upgrade_to_altair, upgrade_to_merge};
 use safe_arith::{ArithError, SafeArith};
 use tree_hash::TreeHash;
+use types::consts::merge_testing::{GENESIS_BASE_FEE_PER_GAS, GENESIS_GAS_LIMIT};
 use types::DEPOSIT_TREE_DEPTH;
 use types::*;
 
@@ -46,11 +47,34 @@ pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
     // use of `BeaconBlock::empty` in `BeaconState::new` is sufficient to correctly initialise
     // the `latest_block_header` as per:
     // https://github.com/ethereum/eth2.0-specs/pull/2323
-    if spec.fork_name_at_epoch(state.current_epoch()) == ForkName::Altair {
+    if spec
+        .altair_fork_epoch
+        .map_or(false, |fork_epoch| fork_epoch == T::genesis_epoch())
+    {
         upgrade_to_altair(&mut state, spec)?;
     }
 
-    // TODO: handle upgrade_to_merge() here
+    // Similarly, perform an upgrade to the merge if configured from genesis.
+    if spec
+        .merge_fork_epoch
+        .map_or(false, |fork_epoch| fork_epoch == T::genesis_epoch())
+    {
+        upgrade_to_merge(&mut state, spec)?;
+
+        // Remove intermediate Altair fork from `state.fork`.
+        state.fork_mut().previous_version = spec.genesis_fork_version;
+
+        // Override latest execution payload header.
+        // See https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/merge/beacon-chain.md#testing
+        *state.latest_execution_payload_header_mut()? = ExecutionPayloadHeader {
+            block_hash: eth1_block_hash,
+            timestamp: eth1_timestamp,
+            random: eth1_block_hash,
+            gas_limit: GENESIS_GAS_LIMIT,
+            base_fee_per_gas: GENESIS_BASE_FEE_PER_GAS,
+            ..ExecutionPayloadHeader::default()
+        };
+    }
 
     // Now that we have our validators, initialize the caches (including the committees)
     state.build_all_caches(spec)?;

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -482,7 +482,9 @@ impl ChainSpec {
             altair_fork_epoch: None,
             merge_fork_version: [0x02, 0x00, 0x00, 0x00],
             merge_fork_epoch: None,
-            terminal_total_difficulty: Uint256::MAX,
+            terminal_total_difficulty: Uint256::MAX
+                .checked_sub(Uint256::from(2u64.pow(10)))
+                .expect("calculation does not overflow"),
 
             /*
              * Network specific
@@ -523,6 +525,9 @@ impl ChainSpec {
             epochs_per_sync_committee_period: Epoch::new(8),
             altair_fork_version: [0x01, 0x00, 0x00, 0x01],
             altair_fork_epoch: None,
+            // Merge
+            merge_fork_version: [0x02, 0x00, 0x00, 0x01],
+            merge_fork_epoch: None,
             // Other
             network_id: 2, // lighthouse testnet network id
             deposit_chain_id: 5,

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -34,7 +34,7 @@ impl ForkName {
                 spec
             }
             ForkName::Merge => {
-                spec.altair_fork_epoch = None;
+                spec.altair_fork_epoch = Some(Epoch::new(0));
                 spec.merge_fork_epoch = Some(Epoch::new(0));
                 spec
             }

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-beta.5
+TESTS_TAG := v1.1.0
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -20,16 +20,19 @@ tests_dir_filename = sys.argv[2]
 # following regular expressions, we will assume they are to be ignored (i.e., we are purposefully
 # *not* running the spec tests).
 excluded_paths = [
-    # Eth1Block
+    # Eth1Block and PowBlock
     #
     # Intentionally omitted, as per https://github.com/sigp/lighthouse/issues/1835
     "tests/.*/.*/ssz_static/Eth1Block/",
+    "tests/.*/.*/ssz_static/PowBlock/",
     # LightClientStore
     "tests/.*/.*/ssz_static/LightClientStore",
     # LightClientUpdate
     "tests/.*/.*/ssz_static/LightClientUpdate",
     # LightClientSnapshot
     "tests/.*/.*/ssz_static/LightClientSnapshot",
+    # Merkle proof tests, omitted for now
+    "tests/.*/.*/merkle/.*",
     # Fork choice
     "tests/.*/*/fork_choice",
 ]

--- a/testing/ef_tests/src/cases/genesis_initialization.rs
+++ b/testing/ef_tests/src/cases/genesis_initialization.rs
@@ -56,9 +56,7 @@ impl<E: EthSpec> LoadCase for GenesisInitialization<E> {
 impl<E: EthSpec> Case for GenesisInitialization<E> {
     fn is_enabled_for_fork(fork_name: ForkName) -> bool {
         // Altair genesis and later requires real crypto.
-        // FIXME(merge): enable merge tests once available
-        fork_name == ForkName::Base
-            || cfg!(not(feature = "fake_crypto")) && fork_name != ForkName::Merge
+        fork_name == ForkName::Base || cfg!(not(feature = "fake_crypto"))
     }
 
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -446,11 +446,6 @@ pub struct GenesisValidityHandler<E>(PhantomData<E>);
 impl<E: EthSpec + TypeName> Handler for GenesisValidityHandler<E> {
     type Case = cases::GenesisValidity<E>;
 
-    // FIXME(merge): enable merge test once available
-    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        fork_name != ForkName::Merge
-    }
-
     fn config_name() -> &'static str {
         E::name()
     }


### PR DESCRIPTION
## Proposed Changes

I made a second implementation of `compute_timestamp_at_slot` in the `SlotClock` as a way to avoid accessing the head during block verification just for getting the `genesis_time`. I didn't replace the original implementation with this new one in the consensus code, because we don't pass the `SlotClock` around there and it keeps that code more similar to the spec.    