### PR TITLE
Suggestions for `optimistic_conditions` branch

### DIFF
--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -43,6 +43,12 @@ pub enum Error<T> {
         block_root: Hash256,
         payload_verification_status: PayloadVerificationStatus,
     },
+    MissingJustifiedBlock {
+        justified_checkpoint: Checkpoint,
+    },
+    MissingFinalizedBlock {
+        finalized_checkpoint: Checkpoint,
+    },
 }
 
 impl<T> From<InvalidAttestation> for Error<T> {
@@ -873,6 +879,29 @@ where
         } else {
             None
         }
+    }
+
+    /// Returns the `ProtoBlock` for the justified checkpoint.
+    ///
+    /// ## Notes
+    ///
+    /// This does *not* return the "best justified checkpoint". It returns the justified checkpoint
+    /// that is used for computing balances.
+    pub fn get_justified_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
+        let justified_checkpoint = self.justified_checkpoint();
+        self.get_block(&justified_checkpoint.root)
+            .ok_or(Error::MissingJustifiedBlock {
+                justified_checkpoint,
+            })
+    }
+
+    /// Returns the `ProtoBlock` for the finalized checkpoint.
+    pub fn get_finalized_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
+        let finalized_checkpoint = self.finalized_checkpoint();
+        self.get_block(&finalized_checkpoint.root)
+            .ok_or(Error::MissingFinalizedBlock {
+                finalized_checkpoint,
+            })
     }
 
     /// Return `true` if `block_root` is equal to the finalized root, or a known descendant of it.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::proto_array::{ProposerBoost, ProtoArray};
+use crate::proto_array::{Iter, ProposerBoost, ProtoArray};
 use crate::ssz_container::SszContainer;
 use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
@@ -37,6 +37,14 @@ pub enum ExecutionStatus {
 }
 
 impl ExecutionStatus {
+    pub fn is_valid(&self) -> bool {
+        matches!(self, ExecutionStatus::Valid(_))
+    }
+
+    pub fn is_execution_enabled(&self) -> bool {
+        !matches!(self, ExecutionStatus::Irrelevant(_))
+    }
+
     pub fn irrelevant() -> Self {
         ExecutionStatus::Irrelevant(false)
     }
@@ -300,6 +308,11 @@ impl ProtoArrayForkChoice {
         } else {
             None
         }
+    }
+
+    /// See `ProtoArray::iter_nodes`
+    pub fn iter_nodes<'a>(&'a self, block_root: &Hash256) -> Iter<'a> {
+        self.proto_array.iter_nodes(block_root)
     }
 
     pub fn as_bytes(&self) -> Vec<u8> {


### PR DESCRIPTION
Whilst reviewing https://github.com/sigp/lighthouse/pull/2986, I noticed an additional condition where it becomes safe to optimistically import a block. I've opened a PR at https://github.com/ethereum/consensus-specs/pull/2841 and "optimistically" (lel) included that change here.

This change is also different to the original since the original was using the justified checkpoint of the *block being imported* (`state.current_justified_checkpoint().root;`) rather than the justified checkpoint of the *head of the chain*.