### PR TITLE
Fix tests failing due to shuffling

### DIFF
--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -1013,8 +1013,8 @@ fn check_shuffling_compatible(
 // Ensure blocks from abandoned forks are pruned from the Hot DB
 #[tokio::test]
 async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1123,8 +1123,8 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
 
 #[tokio::test]
 async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1255,8 +1255,8 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
 
 #[tokio::test]
 async fn pruning_does_not_touch_blocks_prior_to_finalization() {
-    const HONEST_VALIDATOR_COUNT: usize = 16;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8;
+    const HONEST_VALIDATOR_COUNT: usize = 32;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1350,8 +1350,8 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
 
 #[tokio::test]
 async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1495,8 +1495,8 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
 // This is to check if state outside of normal block processing are pruned correctly.
 #[tokio::test]
 async fn prunes_skipped_slots_states() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1624,8 +1624,8 @@ async fn prunes_skipped_slots_states() {
 // This is to check if state outside of normal block processing are pruned correctly.
 #[tokio::test]
 async fn finalizes_non_epoch_start_slot() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -45,6 +45,7 @@ fn get_valid_sync_committee_message(
     harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
     slot: Slot,
     relative_sync_committee: RelativeSyncCommittee,
+    message_index: usize,
 ) -> (SyncCommitteeMessage, usize, SecretKey, SyncSubnetId) {
     let head_state = harness.chain.head_beacon_state_cloned();
     let head_block_root = harness.chain.head_snapshot().beacon_block_root;
@@ -52,7 +53,7 @@ fn get_valid_sync_committee_message(
         .make_sync_committee_messages(&head_state, head_block_root, slot, relative_sync_committee)
         .get(0)
         .expect("sync messages should exist")
-        .get(0)
+        .get(message_index)
         .expect("first sync message should exist")
         .clone();
 
@@ -494,7 +495,7 @@ async fn unaggregated_gossip_verification() {
     let current_slot = harness.chain.slot().expect("should get slot");
 
     let (valid_sync_committee_message, expected_validator_index, validator_sk, subnet_id) =
-        get_valid_sync_committee_message(&harness, current_slot, RelativeSyncCommittee::Current);
+        get_valid_sync_committee_message(&harness, current_slot, RelativeSyncCommittee::Current, 0);
 
     macro_rules! assert_invalid {
             ($desc: tt, $attn_getter: expr, $subnet_getter: expr, $($error: pat_param) |+ $( if $guard: expr )?) => {
@@ -644,7 +645,7 @@ async fn unaggregated_gossip_verification() {
 
     // **Incorrectly** create a sync message using the current sync committee
     let (next_valid_sync_committee_message, _, _, next_subnet_id) =
-        get_valid_sync_committee_message(&harness, target_slot, RelativeSyncCommittee::Current);
+        get_valid_sync_committee_message(&harness, target_slot, RelativeSyncCommittee::Current, 1);
 
     assert_invalid!(
         "sync message on incorrect subnet",

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -19,7 +19,7 @@ use types::{
 };
 
 // Should ideally be divisible by 3.
-pub const VALIDATOR_COUNT: usize = 24;
+pub const VALIDATOR_COUNT: usize = 48;
 
 lazy_static! {
     /// A cached set of keys.


### PR DESCRIPTION
## Detail

This PR fixes some tests that started to fail after @ethDreamer modified the beacon chain harness to intiailize some validators to have eth1 withdrawal addresses.

The reason that these tests fail was rather nuanced:

- Changing the withdrawal credentials in deposits changed the `genesis_validators_root`.
- Changing the `genesis_validators_root` changes the signature domain.
- Changing the signature domain changes the bytes outputted when signing a message.
- Changing the signature bytes changes the randao reveals.
- Changing the rando reveals changes the shuffling.

It turns out that some of our tests were unwittingly relying on a particular shuffling. For example, the `finalizes_with_two_thirds_participation` stops 8 of the total 24 validators from attesting. An unfortunate shuffling of the same set of validators can result in different finalization outcomes.

The sync committee verification tests started failing because the changed shuffling resulted in an validator-already-seen error rather than the expected error.


